### PR TITLE
Fix `get_num_classes` error in training notebook step 6

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,6 @@
 numpy>=1.18.2
 onnx>=1.7.0
+torchmetrics<=0.7.3
 pytorch-lightning>=1.3.0
 python-dateutil
 torch


### PR DESCRIPTION
The TalkNet training notebook installs `pytorch-lightning==1.3.8`, which [imports](https://github.com/Lightning-AI/lightning/blob/1.3.8/pytorch_lightning/metrics/utils.py#L22) `get_num_classes` from the torchmetrics package. However:
- `get_num_classes` was [removed](https://github.com/Lightning-AI/metrics/pull/914/files#diff-739169668978ff62f914849eb3a394b517c00ced020df3aea7d1fc9759760505L148) in v0.8.0, so torchmetrics v0.7.3 is the last version compatible with Lightning v1.3.8.
- Lightning v1.3.8 only [requires](https://github.com/Lightning-AI/lightning/blob/1.3.8/requirements.txt#L10) `torchmetrics>=0.2.0`, so pip can install a version of torchmetrics newer than v0.7.3, leading to this error in step 6 of the training notebook:
  > ImportError: cannot import name 'get_num_classes' from 'torchmetrics.utilities.data'

  This error has occurred quite a few times already ([April 27](https://desuarchive.org/mlp/thread/38391634/#38523767), [May 8](https://desuarchive.org/mlp/thread/38524825/#38567770), [May 25](https://desuarchive.org/mlp/thread/38605052/#38642003), [June 22](https://desuarchive.org/mlp/thread/38718598/#38752992)).

This PR prevents this from happening by requiring `torchmetrics<=0.7.3`. (It should fix the problem, but I haven't tested it myself.) This change could also be made in step 4 of the training notebook, if that's more convenient.