### PR TITLE
Remove dependency problems for migration to torch 1.13

### DIFF
--- a/nemo/collections/asr/__init__.py
+++ b/nemo/collections/asr/__init__.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.collections.asr import data, losses, models, modules
+# from nemo.collections.asr import data, losses, models, modules
+from nemo.collections.asr import data, models, modules
 from nemo.package_info import __version__
 
 # Set collection version equal to NeMo version.

--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -39,7 +39,7 @@ from nemo.collections.asr.parts.utils.vad_utils import (
 )
 from nemo.core.classes import Model
 from nemo.utils import logging, model_utils
-from nemo.utils.exp_manager import NotFoundError
+# from nemo.utils.exp_manager import NotFoundError
 
 try:
     from torch.cuda.amp import autocast

--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -19,7 +19,7 @@ import torch
 from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf, open_dict
 from pytorch_lightning import Trainer
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
 from nemo.collections.asr.data.audio_to_text import AudioToCharWithDursF0Dataset
 from nemo.collections.common.parts.preprocessing import parsers

--- a/nemo/collections/tts/models/fastpitch_hifigan_e2e.py
+++ b/nemo/collections/tts/models/fastpitch_hifigan_e2e.py
@@ -21,7 +21,7 @@ import torch
 from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf
 from pytorch_lightning import Trainer
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
 from nemo.collections.asr.data.audio_to_text import FastPitchDataset
 from nemo.collections.common.parts.preprocessing import parsers

--- a/nemo/collections/tts/models/fastspeech2.py
+++ b/nemo/collections/tts/models/fastspeech2.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Optional
 import torch
 from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf, open_dict
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
 from nemo.collections.common.parts.preprocessing import parsers
 from nemo.collections.tts.helpers.helpers import plot_spectrogram_to_numpy

--- a/nemo/collections/tts/models/fastspeech2_hifigan_e2e.py
+++ b/nemo/collections/tts/models/fastspeech2_hifigan_e2e.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf, open_dict
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
 from nemo.collections.common.parts.preprocessing import parsers
 from nemo.collections.tts.helpers.helpers import plot_spectrogram_to_numpy

--- a/nemo/collections/tts/models/glow_tts.py
+++ b/nemo/collections/tts/models/glow_tts.py
@@ -20,7 +20,7 @@ import torch.utils.data
 from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf
 from pytorch_lightning import Trainer
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
 from nemo.collections.asr.data.audio_to_text import _AudioTextDataset
 from nemo.collections.asr.parts.preprocessing.perturb import process_augmentations

--- a/nemo/collections/tts/models/squeezewave.py
+++ b/nemo/collections/tts/models/squeezewave.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Optional
 import torch
 from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf, open_dict
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
 from nemo.collections.tts.helpers.helpers import OperationMode, waveglow_log_to_tb_func
 from nemo.collections.tts.losses.waveglowloss import WaveGlowLoss

--- a/nemo/collections/tts/models/tacotron2.py
+++ b/nemo/collections/tts/models/tacotron2.py
@@ -19,7 +19,7 @@ import torch
 from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf, open_dict
 from omegaconf.errors import ConfigAttributeError
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 from torch import nn
 
 from nemo.collections.common.parts.preprocessing import parsers

--- a/nemo/collections/tts/models/uniglow.py
+++ b/nemo/collections/tts/models/uniglow.py
@@ -19,7 +19,7 @@ import torch
 from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf, open_dict
 from pystoi import stoi
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
 from nemo.collections.tts.helpers.helpers import OperationMode, waveglow_log_to_tb_func
 from nemo.collections.tts.losses.uniglowloss import UniGlowLoss

--- a/nemo/collections/tts/models/waveglow.py
+++ b/nemo/collections/tts/models/waveglow.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Optional
 import torch
 from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf, open_dict
-from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+# from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
 from nemo.collections.tts.helpers.helpers import OperationMode, waveglow_log_to_tb_func
 from nemo.collections.tts.losses.waveglowloss import WaveGlowLoss

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -30,8 +30,8 @@ from omegaconf import DictConfig, OmegaConf
 
 import nemo
 from nemo.core.neural_types import NeuralType, NeuralTypeComparisonResult
-from nemo.utils import logging
-from nemo.utils.cloud import maybe_download_from_cloud
+# from nemo.utils import logging
+# from nemo.utils.cloud import maybe_download_from_cloud
 from nemo.utils.model_utils import import_class_by_path, maybe_update_config_version
 
 __all__ = ['Typing', 'FileIO', 'Model', 'Serialization', 'typecheck']

--- a/nemo/utils/__init__.py
+++ b/nemo/utils/__init__.py
@@ -16,7 +16,7 @@
 from nemo.utils.app_state import AppState
 from nemo.utils.nemo_logging import Logger as _Logger
 from nemo.utils.nemo_logging import LogMode as logging_mode
-from nemo.utils.lightning_logger_patch import add_memory_handlers_to_pl_logger
+# from nemo.utils.lightning_logger_patch import add_memory_handlers_to_pl_logger
 
 logging = _Logger()
-add_memory_handlers_to_pl_logger()
+# add_memory_handlers_to_pl_logger()


### PR DESCRIPTION
The new computer has a GPU that only works with torch 1.13.  Thus, we have to get it working.  The new versions I think will be.  Unfortunately these break our NeMo installation.  However, the changes in this PR should fix it.  
```
print(torchaudio.__version__)
print(torch.__version__)
print(torchvision.__version__)
print(torchtext.__version__)
print(pytorch_lightning.__version__)

0.13.1+cu117
1.13.1+cu117
0.14.1+cu117
0.14.1
1.8.6

Some of the changes were made prior to the lightning update, and so may not be 100% necessary.  However, I don't think this is an issue.  In general, I think these version changes require some testing before going to master in Uberduck.  However, the models trained with these new versions should work in the current prod environment, just not on A6000 (sm_86) GPUs.